### PR TITLE
Fixes the 404 link from OBS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.2"
 gem "jekyll-sitemap", "~> 1.4.0"
+gem "jekyll-redirect-from", "~> 0.16.0"
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-sitemap (1.4.0)
@@ -67,6 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3.2)
+  jekyll-redirect-from (~> 0.16.0)
   jekyll-sitemap (~> 1.4.0)
   tzinfo (>= 1, < 3)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 url: https://support.joystick.tv
 plugins:
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 # Theme settings
 theme:

--- a/live_streaming.md
+++ b/live_streaming.md
@@ -3,6 +3,8 @@ layout: default
 keywords:
 
 title: Live Streaming
+redirect_from:
+  - /support/creator-support/setting-up-your-stream/
 ---
 
 ## Getting Started


### PR DESCRIPTION
We can now add other legacy routes we need to redirect.