### PR TITLE
Fixes top-nav opacity for dark mode.

### DIFF
--- a/theme/_includes/site-header.html
+++ b/theme/_includes/site-header.html
@@ -10,7 +10,7 @@
 		 		</svg>
 			</a>
 		</div>
-		<div class="fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:left-72 lg:z-30 lg:px-8 xl:left-80 backdrop-blur-sm dark:backdrop-blur lg:left-72 xl:left-80 bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]" style="--bg-opacity-light:0.5;--bg-opacity-dark:0.2">
+		<div class="fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between gap-12 px-4 transition sm:px-6 lg:left-72 lg:z-30 lg:px-8 xl:left-80 backdrop-blur-sm dark:backdrop-blur lg:left-72 xl:left-80 bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]" style="--bg-opacity-light:0.5;--bg-opacity-dark:0.75">
 			<div class="absolute inset-x-0 top-full h-px transition bg-zinc-900/7.5 dark:bg-white/7.5"></div>
 			{% include site-search.html %}
 			<div class="flex items-center gap-5 lg:hidden">


### PR DESCRIPTION
The opacity for the top navigation should not be less than ~0.6 due to very horrible accessibility, and at 0.2 it is virtually unreadable when sitting over highlighted text blocks.