### PR TITLE
Added response_type query param.

### DIFF
--- a/developer_support.md
+++ b/developer_support.md
@@ -83,8 +83,9 @@ https://joystick.tv/api/oauth/authorize
 
 You will need to pass the following query params
 
-`client_id` - Your bot's Client ID
-`scope` - "bot"
+`response_type` - Required &mdash; the value must be set to `code`
+`client_id` - Required &mdash; Your bot's Client ID
+`scope` - "bot" &mdash; Not used currently.
 `state` - This is an optional string value you can use for validation to ensure data has not been tampered with between OAuth2 transactions.
 
 Example:


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc6749#page-24

`response_type` REQUIRED.  Value MUST be set to "code".

Validated that Joystick server accepts this param, and completes flow successfully.

P.S.. sorry for all the nitpicks.
♥