### PR TITLE
Fix Content-Type for OAuth2 flow

### DIFF
--- a/developer_support.md
+++ b/developer_support.md
@@ -84,9 +84,9 @@ https://joystick.tv/api/oauth/authorize
 
 You will need to pass the following query params
 
-* `response_type` - Required &mdash; the value must be set to `code`<br />
-* `client_id` - Required &mdash; Your bot's Client ID<br />
-* `scope` - "bot" &mdash; Not used currently.<br />
+* `response_type` - Required &mdash; the value must be set to `code`
+* `client_id` - Required &mdash; Your bot's Client ID
+* `scope` - "bot" &mdash; Not used currently.
 * `state` - This is an optional string value you can use for validation to ensure data has not been tampered with between OAuth2 transactions.
 
 Example:
@@ -118,7 +118,7 @@ You will need to pass the following query params
 As well as the following headers
 
 * `Authorization` - "Basic YOUR_BASIC_KEY". This is HTTP Basic auth using your bot's Client ID as the user, and Client Secret as the password separated by a `:` and converted to Base64. (e.g. `Base64.encode("id:secret")`)
-* `Content-Type` - "application/json"
+* `Content-Type` - "application/x-www-form-urlencoded"
 * `X-JOYSTICK-STATE` - An optional value you can use to pass through arbitrary data that will be sent back with the response.
 
 
@@ -127,7 +127,7 @@ Example:
 ```bash
 curl -XPOST \
   -H "Authorization: Basic YOUR_BASIC_KEY" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
   "https://joystick.tv/api/oauth/token?redirect_uri=unused&code=YOUR_OAUTH_CODE&grant_type=authorization_code"
 ```
 
@@ -160,7 +160,7 @@ You will need to pass the following query params
 As well as the following headers
 
 * `Authorization` - "Basic YOUR_BASIC_KEY". This is HTTP Basic auth using your bot's Client ID as the user, and Client Secret as the password separated by a `:` and converted to Base64. (e.g. `Base64.encode("id:secret")`)
-* `Content-Type` - "application/json"
+* `Content-Type` - "application/x-www-form-urlencoded"
 * `X-JOYSTICK-STATE` - An optional value you can use to pass through arbitrary data that will be sent back with the response.
 
 
@@ -169,7 +169,7 @@ Example:
 ```bash
 curl -XPOST \
   -H "Authorization: Basic YOUR_BASIC_KEY" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
   "https://joystick.tv/api/oauth/token?refresh_token=YOUR_REFRESH_TOKEN&grant_type=refresh_token"
 ```
 

--- a/developer_support.md
+++ b/developer_support.md
@@ -120,6 +120,7 @@ As well as the following headers
 * `Authorization` - "Basic YOUR_BASIC_KEY". This is HTTP Basic auth using your bot's Client ID as the user, and Client Secret as the password separated by a `:` and converted to Base64. (e.g. `Base64.encode("id:secret")`)
 * `Content-Type` - "application/x-www-form-urlencoded"
 * `X-JOYSTICK-STATE` - An optional value you can use to pass through arbitrary data that will be sent back with the response.
+* `Accept` - Header indicating that the client expects a response in the `application/json` format.
 
 
 Example:
@@ -128,6 +129,7 @@ Example:
 curl -XPOST \
   -H "Authorization: Basic YOUR_BASIC_KEY" \
   -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Accept: application/json" \
   "https://joystick.tv/api/oauth/token?redirect_uri=unused&code=YOUR_OAUTH_CODE&grant_type=authorization_code"
 ```
 
@@ -162,6 +164,7 @@ As well as the following headers
 * `Authorization` - "Basic YOUR_BASIC_KEY". This is HTTP Basic auth using your bot's Client ID as the user, and Client Secret as the password separated by a `:` and converted to Base64. (e.g. `Base64.encode("id:secret")`)
 * `Content-Type` - "application/x-www-form-urlencoded"
 * `X-JOYSTICK-STATE` - An optional value you can use to pass through arbitrary data that will be sent back with the response.
+* `Accept` - Header indicating that the client expects a response in the `application/json` format.
 
 
 Example:
@@ -170,6 +173,7 @@ Example:
 curl -XPOST \
   -H "Authorization: Basic YOUR_BASIC_KEY" \
   -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Accept: application/json" \
   "https://joystick.tv/api/oauth/token?refresh_token=YOUR_REFRESH_TOKEN&grant_type=refresh_token"
 ```
 


### PR DESCRIPTION
Content-Type `application/x-www-form-urlencoded` as per https://datatracker.ietf.org/doc/html/rfc6749#section-6


Tested flow and it works correctly.

(also cleaned up the line-breaks I left in)