### PR TITLE
Changed dark mode code block FG and BG

### DIFF
--- a/theme/assets/css/style.scss
+++ b/theme/assets/css/style.scss
@@ -147,6 +147,11 @@ html.dark {
       border-left-color: #dfeaff;
     }
   }
+
+  .language-plaintext.highlighter-rouge {
+    background-color: rgba(9, 171, 171, 0.36);
+    color: #e9e9ea;
+  }
 }
 
 @media only screen


### PR DESCRIPTION
Added `Rouge`'s class to .dark class to overwrite code blocks for a friendlier view while using dark theme.  (Global)

I tried to blend it with the overall style of the Joystick Logo. While maintaining WCAG AA+ or higher accessibility rating.